### PR TITLE
Simplify API to be more string oriented.

### DIFF
--- a/src/multiaddr.erl
+++ b/src/multiaddr.erl
@@ -26,13 +26,8 @@
 
 -export([new/1, to_string/1, protocols/1]).
 
--spec new(string() | binary()) -> multiaddr() | {error, term()}.
-new(Bin) when is_binary(Bin) ->
-    case to_string(Bin) of
-        Result when is_list(Result) -> Bin;
-        Error -> Error
-    end;
-new(Str) ->
+-spec new(string()) -> multiaddr().
+new(Str) when is_list(Str) ->
     Trimmed = string:strip(Str, right, $/),
     try
         case string:split(Trimmed, "/", all) of
@@ -40,29 +35,29 @@ new(Str) ->
             _ -> throw({error, missing_prefix})
         end
     catch
-        throw:{error, Error} -> {error, Error}
+        throw:{error, _} -> error(bad_arg)
     end.
 
--spec to_string(multiaddr() | [protocol()]) -> string() | {error, term()}.
+-spec to_string(multiaddr() | [protocol()]) -> string().
 to_string(Addr) when is_binary(Addr) ->
     try
         decode_bytes(Addr, "")
     catch
-        throw:{error, Error} -> {error, Error}
+        throw:{error, _} -> error(bad_arg)
     end;
 to_string(Protocols) when is_list(Protocols) ->
     try
         decode_protocols(Protocols)
     catch
-        throw:{error, Error} -> {error, Error}
+        throw:{error, _} -> error(bad_arg)
     end.
 
--spec protocols(multiaddr()) -> [protocol()] | {error, term()}.
+-spec protocols(multiaddr()) -> [protocol()].
 protocols(Addr) ->
     try
         protocols(Addr, [])
     catch
-        throw:{error, Error} -> {error, Error}
+        throw:{error, _} -> error(bad_arg)
     end.
 
 protocols(<<>>, Acc) ->
@@ -144,4 +139,3 @@ decode_protocols([{Addr, undefined} | Rest]) ->
     "/" ++ Addr ++ decode_protocols(Rest);
 decode_protocols([{Addr, Value} | Rest]) ->
     "/" ++ Addr ++ "/" ++ Value ++ decode_protocols(Rest).
-

--- a/test/multiaddr_test.erl
+++ b/test/multiaddr_test.erl
@@ -73,7 +73,7 @@ encode_fail_test() ->
              "/ip4/1.2.3.4/tcp/80/unix"
             ],
     lists:map(fun(Case) ->
-                      ?assertMatch({error, _}, multiaddr:new(Case))
+                      ?assertError(bad_arg, multiaddr:new(Case))
               end, Cases).
 
 
@@ -81,13 +81,13 @@ encode_binary_test() ->
     Cases = [ {"/ip4/127.0.0.1/udp/1234", "047f000001910204d2"},
               {"/ip4/127.0.0.1/tcp/4321", "047f0000010610e1"},
               {"/ip4/127.0.0.1/udp/1234/ip4/127.0.0.1/tcp/4321", "047f000001910204d2047f0000010610e1"},
-              {"/onion/aaimaq4ygg2iegci:80", "bc030010c0439831b48218480050"} 
+              {"/onion/aaimaq4ygg2iegci:80", "bc030010c0439831b48218480050"}
             ],
     lists:map(fun({Str, Enc}) ->
                       Address = multiaddr:new(Str),
                       Encoded = string:uppercase(Enc),
                       ?assertEqual(Encoded, hex:bin_to_hexstr(Address)),
-                      ?assertEqual(Address, multiaddr:new(hex:hexstr_to_bin(Enc)))
+                      ?assertEqual(Address, multiaddr:new(multiaddr:to_string(hex:hexstr_to_bin(Enc))))
               end, Cases).
 
 
@@ -97,4 +97,3 @@ protocols_test() ->
     ?assertEqual(2, length(Protocols)),
     ?assertMatch([{"ip4", "127.0.0.1"}, {"udp", "1234"}], Protocols),
     ?assertEqual(Address, multiaddr:new(multiaddr:to_string(Protocols))).
-    


### PR DESCRIPTION
This change will throw errors instead of returning them since that is
the more normal usecase of the library.

We will rev the library to 1.1.0 to reflect this breaking api change